### PR TITLE
cluster: Align `cluster_base` ports exposing

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   cva6:                   { path: hw/vendor/openhwgroup_cva6                                                }
   opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                             }
   register_interface:     { git:  https://github.com/pulp-platform/register_interface.git, version: 0.3.8   }
-  snitch_cluster:         { git:  https://github.com/pulp-platform/snitch_cluster.git,     rev:     ae02a03d7d401ed486dac80a3a1d77e1a89c395d }
+  snitch_cluster:         { git:  https://github.com/pulp-platform/snitch_cluster.git,     rev:     ed0b98162fae196faff96a972f861a0aa4593227 }
   tech_cells_generic:     { git:  https://github.com/pulp-platform/tech_cells_generic.git, rev:     v0.2.11 }
 
 workspace:

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -56,7 +56,7 @@ class Occamy(Generator):
         # Overwrite boot address with base of bootrom
         self.cluster.cfg["boot_addr"] = self.cfg["peripherals"]["rom"]["address"]
 
-        self.cluster.cfg['tie_ports'] = False
+        self.cluster.cfg['cluster_base_expose'] = True
 
         if "ro_cache_cfg" in self.cfg["s1_quadrant"]:
             ro_cache = self.cfg["s1_quadrant"]["ro_cache_cfg"]


### PR DESCRIPTION
Alings with the snitch cluster PR https://github.com/pulp-platform/snitch_cluster/pull/62 that allows to expose the `cluster_base` ports.

### TODO:

- [x] Merge https://github.com/pulp-platform/snitch_cluster/pull/62
- [ ] Update snitch cluster version/revision. Currently `occamy` branch of snitch cluster is used