### PR TITLE
cva6: Bump FPU to align with Snitch cluster version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docs
-        run: mkdocs build
+        run: |
+          bender update && bender checkout
+          mkdocs build
 
   #######################
   # Build SW for Occamy #

--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   cva6:                   { path: hw/vendor/openhwgroup_cva6                                                }
   opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                             }
   register_interface:     { git:  https://github.com/pulp-platform/register_interface.git, version: 0.3.8   }
-  snitch_cluster:         { git:  https://github.com/pulp-platform/snitch_cluster.git,     rev:     0c226e2b7aa884fa15bacebe1f52ba5d2b6d8e37 }
+  snitch_cluster:         { git:  https://github.com/pulp-platform/snitch_cluster.git,     rev:     3c73ab9ed1f3518ca50902e06ac07579c6288069 }
   tech_cells_generic:     { git:  https://github.com/pulp-platform/tech_cells_generic.git, rev:     v0.2.11 }
 
 workspace:

--- a/hw/vendor/openhwgroup_cva6/Bender.lock
+++ b/hw/vendor/openhwgroup_cva6/Bender.lock
@@ -22,10 +22,10 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   fpnew:
-    revision: 8dc44406b1ccbc4487121710c1883e805f893965
-    version: 0.6.6
+    revision: a8e0cba6dd50f357ece73c2c955d96efc3c6c315
+    version: null
     source:
-      Git: https://github.com/pulp-platform/fpnew.git
+      Git: https://github.com/pulp-platform/cvfpu.git
     dependencies:
     - common_cells
     - fpu_div_sqrt_mvp

--- a/hw/vendor/openhwgroup_cva6/Bender.yml
+++ b/hw/vendor/openhwgroup_cva6/Bender.yml
@@ -8,7 +8,7 @@ package:
 dependencies:
   axi: {git: https://github.com/pulp-platform/axi.git, rev: v0.39.0-beta.4}
   common_cells: {git: https://github.com/pulp-platform/common_cells.git, rev: v1.28.0}
-  fpnew: {git: https://github.com/openhwgroup/cvfpu.git, rev: 1202ca3a767b563bca5de505574373e53941506f}
+  fpnew: { git: "https://github.com/pulp-platform/cvfpu.git", rev: pulp-v0.1.3 }
   tech_cells_generic: {git: https://github.com/pulp-platform/tech_cells_generic.git, rev: v0.2.11}
 
 frozen: true

--- a/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv
+++ b/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv
@@ -518,6 +518,7 @@ module fpu_wrap import ariane_pkg::*; (
     ) i_fpnew_bulk (
       .clk_i,
       .rst_ni,
+      .hart_id_i      ( '0                                  ),
       .operands_i     ( fpu_operands                        ),
       .rnd_mode_i     ( fpnew_pkg::roundmode_e'(fpu_rm)     ),
       .op_i           ( fpnew_pkg::operation_e'(fpu_op)     ),
@@ -527,6 +528,7 @@ module fpu_wrap import ariane_pkg::*; (
       .int_fmt_i      ( fpnew_pkg::int_format_e'(fpu_ifmt)  ),
       .vectorial_op_i ( fpu_vec_op                          ),
       .tag_i          ( fpu_tag                             ),
+      .simd_mask_i    ( '1                                  ),
       .in_valid_i     ( fpu_in_valid                        ),
       .in_ready_o     ( fpu_in_ready                        ),
       .flush_i,

--- a/hw/vendor/patches/openhwgroup_cva6/0008-cva6-Update-git-dependencies.patch
+++ b/hw/vendor/patches/openhwgroup_cva6/0008-cva6-Update-git-dependencies.patch
@@ -26,7 +26,7 @@ index 84b4ab8..a12628b 100644
 -    }
 +  axi: {git: https://github.com/pulp-platform/axi.git, rev: v0.39.0-beta.4}
 +  common_cells: {git: https://github.com/pulp-platform/common_cells.git, rev: v1.28.0}
-+  fpnew: {git: https://github.com/openhwgroup/cvfpu.git, rev: 1202ca3a767b563bca5de505574373e53941506f}
++  fpnew: { git: "https://github.com/pulp-platform/cvfpu.git", rev: pulp-v0.1.3 }
 +  tech_cells_generic: {git: https://github.com/pulp-platform/tech_cells_generic.git, rev: v0.2.11}
  
  frozen: true

--- a/hw/vendor/patches/openhwgroup_cva6/0009-Update-FPU-wrap-in-CVA6.patch
+++ b/hw/vendor/patches/openhwgroup_cva6/0009-Update-FPU-wrap-in-CVA6.patch
@@ -1,0 +1,32 @@
+From 2c8a75b2fc38f89377d4731d81e074311ed89014 Mon Sep 17 00:00:00 2001
+From: Luca Bertaccini <lbertaccini@iis.ee.ethz.ch>
+Date: Mon, 15 Jan 2024 14:29:47 +0100
+Subject: [PATCH] Update FPU wrap in CVA6
+
+---
+ hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv b/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv
+index 1dbe526..1d5cda3 100644
+--- a/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv
++++ b/hw/vendor/openhwgroup_cva6/core/fpu_wrap.sv
+@@ -518,6 +518,7 @@ module fpu_wrap import ariane_pkg::*; (
+     ) i_fpnew_bulk (
+       .clk_i,
+       .rst_ni,
++      .hart_id_i      ( '0                                  ),
+       .operands_i     ( fpu_operands                        ),
+       .rnd_mode_i     ( fpnew_pkg::roundmode_e'(fpu_rm)     ),
+       .op_i           ( fpnew_pkg::operation_e'(fpu_op)     ),
+@@ -527,6 +528,7 @@ module fpu_wrap import ariane_pkg::*; (
+       .int_fmt_i      ( fpnew_pkg::int_format_e'(fpu_ifmt)  ),
+       .vectorial_op_i ( fpu_vec_op                          ),
+       .tag_i          ( fpu_tag                             ),
++      .simd_mask_i    ( '1                                  ),
+       .in_valid_i     ( fpu_in_valid                        ),
+       .in_ready_o     ( fpu_in_ready                        ),
+       .flush_i,
+-- 
+2.16.5
+


### PR DESCRIPTION
Aligns Occamy with the Snitch cluster after merging https://github.com/pulp-platform/snitch_cluster/pull/66.